### PR TITLE
Create shipping methods

### DIFF
--- a/backend/bootstrap.rb
+++ b/backend/bootstrap.rb
@@ -12,11 +12,72 @@ class Payment
     @authorization_number = Time.now.to_i
     @invoice = Invoice.new(billing_address: order.address, shipping_address: order.address, order: order)
     @paid_at = paid_at
+    order.items.each do |item|
+      item.shipping_method()
+    end
     order.close(@paid_at)
   end
 
   def paid?
     !paid_at.nil?
+  end
+end
+
+class Book
+  def ship_it(context)
+    shipping_label(context)
+  end
+
+  private
+
+  def shipping_label(item)
+    p "shipping label for #{item.product.name}, tax free"
+  end
+end
+
+class Physical
+  def ship_it(context)
+    shipping_label(context)
+  end
+
+  private
+
+  def shipping_label(item)
+    p "shipping label for #{item.product.name}"
+  end
+end
+
+class Signature
+  def ship_it(context)
+    activate_signature()
+    send_notification(context)
+  end
+
+  private
+
+  def send_notification(item)
+    p "send notification for #{item.product.name}"
+  end
+
+  def activate_signature()
+    p "Signature activated"
+  end
+end
+
+class Media
+  def ship_it(context)
+    send_description(context)
+    add_customer_voucher(context.order.customer)
+  end
+
+  private
+
+  def send_description(item)
+    p "Send description for #{item.product.name}"
+  end
+
+  def add_customer_voucher(customer)
+    p "Voucher to #{customer}"
   end
 end
 
@@ -66,6 +127,10 @@ class OrderItem
   def total
     10
   end
+
+  def shipping_method
+    self.product.type.ship_it(self)
+  end
 end
 
 class Product
@@ -101,7 +166,7 @@ end
 
 # Book Example (build new payments if you need to properly test it)
 foolano = Customer.new
-book = Product.new(name: 'Awesome book', type: :book)
+book = Product.new(name: 'Awesome book', type: Book.new())
 book_order = Order.new(foolano)
 book_order.add_product(book)
 
@@ -110,4 +175,32 @@ payment_book.pay
 p payment_book.paid? # < true
 p payment_book.order.items.first.product.type
 
-# now, how to deal with shipping rules then?
+siclano = Customer.new
+tv = Product.new(name: 'Dumb Tv', type: Physical.new())
+tv_order = Order.new(siclano)
+tv_order.add_product(tv)
+
+payment_tv = Payment.new(order: tv_order, payment_method: CreditCard.fetch_by_hashed('43567890-987654367'))
+payment_tv.pay
+p payment_tv.paid? # < true
+p payment_tv.order.items.first.product.type
+
+beltrano = Customer.new
+wine_pack = Product.new(name: 'Monthly wine pack', type: Signature.new())
+wine_pack_order = Order.new(beltrano)
+wine_pack_order.add_product(wine_pack)
+
+payment_wine = Payment.new(order: wine_pack_order, payment_method: CreditCard.fetch_by_hashed('43567890-987654367'))
+payment_wine.pay
+p payment_wine.paid? # < true
+p payment_wine.order.items.first.product.type
+
+geek = Customer.new
+album = Product.new(name: 'Disc album', type: Media.new())
+album_order = Order.new(geek)
+album_order.add_product(album)
+
+payment_album = Payment.new(order: album_order, payment_method: CreditCard.fetch_by_hashed('43567890-987654367'))
+payment_album.pay
+p payment_album.paid? # < true
+p payment_album.order.items.first.product.type

--- a/backend/consideracoes.txt
+++ b/backend/consideracoes.txt
@@ -1,0 +1,7 @@
+Decidi alterar a implementação original e transformar o tipo do produto em um objeto, para poder trabalhar as diferenças no método de envio de cada um.
+Alterei também a classe OrderItem para acrescentar uma função que gerencia o método de envio conforme o tipo do item, de forma transparente para quem está consumindo.
+Usei a mesma interface nas classes criadas, o método de envio recebe o proprio item como argumento para ser manipulado conforme cada especificação.
+A interação com os métodos de envio acontece na ação de pagamento da ordem.
+Quis dessa forma, evitar o uso de condicionais e facilitar no caso de novos métodos de envio incluidos no projeto.
+
+Estou disponível para qualquer esclarecimento.


### PR DESCRIPTION
Why:

To create a logic with different shipping methods without the use of
if/else statements

This change addresses the need by:

* attr product type becomes a Class
* Create a class for each shipping method
* Refactoring OrderItem to create a public function with the call of
corresponding ship_it method