### PR TITLE
Permits test libs explicitly

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,7 +15,7 @@ Crie as classes, métodos e suas respectivas chamadas para que recebendo um _inp
 
 **Não é necessário** criar as implementações para envio de e-mails, imprimir o _shipping label_, etc. Para estes casos (email, shipping label) crie apenas as chamadas de métodos, para indicar que ali seria o local aonde o envio ocorreria.
 
-Como a proposta **não requer um código final funcionando**, não há a necessidade de implementar os testes de unidade. Entretanto, levaremos isso como _bonus points_.
+Como a proposta **não requer um código final funcionando**, não há a necessidade de implementar os testes de unidade. Entretanto, levaremos isso como _bonus points_. É permitido o uso de libs para facilitar a implementação dos testes.
 
 __O que está sob avaliação?__
 


### PR DESCRIPTION
Não é a primeira vez que o candidato cria sua própria lib interna de teste, como no exemplo abaixo:
 
https://github.com/Creditas/challenge/pull/38/files#diff-94297dc25c044b5105f1c209407f4f62R1
https://github.com/Creditas/challenge/pull/38/files#diff-da8dd22a33b385872f8f99a1d282739eR1
https://github.com/Creditas/challenge/pull/38/files#diff-a4d4c618af98b7129dc6833bd45aa19aR1

Para evitar ou minimizar esse tipo de situação, adicionei um comentário que explicita a possibilidade de usar lib de teste. 