### PR TITLE
Alterar GitLab para GitHub no Readme

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -40,8 +40,6 @@ __Apresentação__
   - Explicação da solução (em arquivo separado em Markdown/Plain Text)
 
 __Avaliação__
-
 Para nos enviar seu código, você pode:
-
- - Fazer um fork desse repositório, e nos mandar uma pull-request.
- - Dar acesso ao seu repositório privado no [Gitlab](http://gitlab.com) para `creditaschallenge`.
+- Dar acesso ao seu repositório *privado* no [GitHub](http://github.com) para `???`.
+- Enviar um `git bundle` do seu repositório para o e-mail `challenge@creditas.com.br`.

--- a/backend/README_English.md
+++ b/backend/README_English.md
@@ -40,8 +40,6 @@ __Presentation__
   - Explanation of the solution (in separate file in Markdown / Plain Text)
 
 __Evaluation__
-
 To send us your code, you can:
-
- - Make a fork of this repository, and send us a pull-request.
- - Give access to your private repository in gitlab to `creditaschallenge`.
+- Give access to your *private* repository on [GitHub](http://github.com) to `???`.
+- Enviar um `git bundle` do seu repositório para o e-mail `challenge@creditas.com.br`.

--- a/data-science/README.md
+++ b/data-science/README.md
@@ -1,7 +1,7 @@
 # Desafio Data Science
 
 ## Objetivo
-- Implementar um modelo que retorne a probabilidade que um cliente tem de ser enviado para análise de crédito dado que ele foi pré-aprovado para o empréstimo com garantia de automóvel. 
+- Implementar um modelo que retorne a probabilidade que um cliente tem de ser enviado para análise de crédito dado que ele foi pré-aprovado para o empréstimo com garantia de automóvel.
 - Além da implementação do modelo é esperado que o candidato faça a **avaliação** do mesmo, de maneira a entender o motivo pelo qual o modelo apresentado resolve o problema, incluindo quais atributos são mais importantes para o modelo e o motivo.
 - É necessário apresentar também a **análise exploratória dos dados**, incluindo as variáveis que foram eliminadas e os motivos.
 
@@ -26,5 +26,5 @@
 
 ## Avaliação
 Para nos enviar seu código, você pode:
- - Dar acesso ao seu repositório privado no [Gitlab](http://gitlab.com) para `creditaschallenge`.
-- Mandar um email para `ds-squad@creditas.com.br`
+- Dar acesso ao seu repositório *privado* no [GitHub](http://github.com) para `???`.
+- Enviar um `git bundle` do seu repositório para o e-mail `challenge@creditas.com.br`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,32 +1,30 @@
 ## Teste frontend - Creditas
 
-Esse é um teste focado em design de código, e conhecimento de orientação a 
-objeto. O objetivo é avaliar sua experiênica em escrever código de fácil 
+Esse é um teste focado em design de código, e conhecimento de orientação a
+objeto. O objetivo é avaliar sua experiênica em escrever código de fácil
 manutenção, baixo acoplamento, e alta coesão.
 
 ### Apresentação do problema
 
-O arquivo `index.html` contém o esqueleto de uma aplicação de chat totalmente 
-*bare-bones*: uma `<ul>` com uma lista de mensagens enviadas, e um `<button>` + `<input>` 
+O arquivo `index.html` contém o esqueleto de uma aplicação de chat totalmente
+*bare-bones*: uma `<ul>` com uma lista de mensagens enviadas, e um `<button>` + `<input>`
 para envio de novas mensagens.
 
-A feature inicial de nossa aplicação é bastante simples: o usuário deve poder 
-entrar uma mensagem na caixa de texto e, ao apertar o botão "Enviar" (ou 
+A feature inicial de nossa aplicação é bastante simples: o usuário deve poder
+entrar uma mensagem na caixa de texto e, ao apertar o botão "Enviar" (ou
 pressionar <kbd>Enter</kbd>), a mensagem deverá aparecer na lista de mensagens.
 
-Isoladamente essa é uma feature simples de implementar, mas queremos que você 
-leve em conta a evolução futura do software. Imagine que o app irá crescer em 
+Isoladamente essa é uma feature simples de implementar, mas queremos que você
+leve em conta a evolução futura do software. Imagine que o app irá crescer em
 features, e adicionar coisas como:
 * envio de mensagens via ajax, com as respostas vindo via `long-polling`
 * chat em realtime via WebRTC
 * ter vários chats visíveis ao mesmo tempo, adicionadas dinamicamente com base nas ações do usuário
 
-Você deve pensar num design de código que suporte esses casos de uso sem 
+Você deve pensar num design de código que suporte esses casos de uso sem
 grandes modificações.
 
 ### Avaliação
-
 Para nos enviar seu código, você pode:
-* Fazer um fork desse repositório e nos mandar uma pull-request
-* Dar acesso ao seu repositório privado no [Github](http://github.com) ou [Gitlab](http://gitlab.com) para `creditaschallenge`.
-* Enviar um `git bundle` do seu repositório para o e-mail challenge@creditas.com.br
+- Dar acesso ao seu repositório *privado* no [Github](http://github.com) para `???`.
+- Enviar um `git bundle` do seu repositório para o e-mail `challenge@creditas.com.br`.

--- a/qa-test/README.md
+++ b/qa-test/README.md
@@ -65,8 +65,6 @@ Crie um teste que cria um post através da API. Valide que o post foi criado atr
 * **Explicação da solução de automação dos testes (em arquivo separado em Markdown/Plain Text)**
 
 # Avaliação
-
 Para nos enviar seu código, você pode:
-
-* Fazer um fork desse repositório, e nos mandar uma pull-request.
-* Dar acesso ao seu repositório privado no GitHub ou GitLab para `creditaschallenge`.
+- Dar acesso ao seu repositório *privado* no [GitHub](http://github.com) para `???`.
+- Enviar um `git bundle` do seu repositório para o e-mail `challenge@creditas.com.br`.


### PR DESCRIPTION
### ⚠️ Este PR contém um block ⚠️ 
*resolver esta flag abaixo antes de fazer merge!*
- Editar todos os readme's para trocar `???` pelo user padrão da Creditas do GitHub

### Motivação
O GitHub em 2019 liberou repositórios privados gratuitos.
Repositórios privados evitam problemas como:
- Privacidade e autoria do candidato
- Confidencialidade do nosso processo seletivo

O GitHub já faz parte da nossa stack de ferramentas. Concentrar nosso processo em uma única ferramenta visa trazer mais produtividade.

### O que foi feito?
- Removido o GitLab das opções
- Adicionada a opção de `git bundle` para enviar por e-mail em todos os challenges
- Minor Fixes em formatação


