### PR TITLE
Update how to send challenge sollution in DS

### DIFF
--- a/data-science/README.md
+++ b/data-science/README.md
@@ -38,8 +38,8 @@ Utilizando um jupyter notebook, apresente a sua solução em python.
 
 ## Como entregar o desafio?
 Para nos enviar seu código, você pode:
-- Dar acesso ao seu repositório privado no [Gitlab](http://gitlab.com) para o usuário `creditaschallenge`.
-- Mandar um email para `ds-squad@creditas.com.br`
+- Comprimir os arquivos do seu desafio em formato `.zip` ou equivalente.
+- Mandar um email para `ds-squad@creditas.com.br`.
 
 
 ### Dicas


### PR DESCRIPTION
## Contexto/ O quê?
O atual formato de enviar o desafio via GitLab causava mais problemas do que solucionava:

* Constantemente a pessoa candidata não marcava o usuário `creditaschallenge` corretamente, precisando rever as permissões por diversas vezes
* Algumas pessoas do time não conseguiam acessar o repositório compartilhado, fazendo com que a Team Leader tivesse que repassar manualmente o desafio em formato `.zip`