### PR TITLE
Translate loan type

### DIFF
--- a/backend/code-challenges/README.md
+++ b/backend/code-challenges/README.md
@@ -12,7 +12,7 @@ Abaixo seguem as regras de negócio relacionadas a concessão de empréstimo de 
 |                          | Empréstimo pessoal | Empréstimo c/ garantia | Consignado |
 | ------------------------ | ------------------ | :--------------------: | ---------- |
 | Salario <= 3000          | Sim                |       Sim\*\*\*        | Não        |
-| Salario > 3000 e < 5000 | Sim                |        Sim\*\*         | Não        |
+| Salario > 3000 e < 5000  | Sim                |        Sim\*\*         | Não        |
 | Salário => 5000          | Sim                |         Sim\*          | Sim        |
 
 - \* Clientes com menos de 30 anos

--- a/backend/code-challenges/java/src/main/java/LoanMatcher.java
+++ b/backend/code-challenges/java/src/main/java/LoanMatcher.java
@@ -12,7 +12,7 @@ public class LoanMatcher {
         List<Loan> loans = new ArrayList<>();
 
         if (customer.income() <= 3000) {
-            loans.add(new Loan("EMPRESTIMO_PESSOAL"));
+            loans.add(new Loan("PERSONAL_LOAN"));
         }
 
         return loans;

--- a/backend/code-challenges/java/src/test/java/LoanMatcherTest.java
+++ b/backend/code-challenges/java/src/test/java/LoanMatcherTest.java
@@ -15,6 +15,6 @@ class LoanMatcherTest {
         assertThat(availableLoans.size()).isEqualTo(1);
 
         assertThat(availableLoans.stream().findFirst().isPresent()).isTrue();
-        assertThat(availableLoans.get(0).type()).isEqualTo("EMPRESTIMO_PESSOAL");
+        assertThat(availableLoans.get(0).type()).isEqualTo("PERSONAL_LOAN");
     }
 }


### PR DESCRIPTION
**Why?**
The type value for personal loans was in portuguese, but all the code is in english.

**What?**
- Change **LoanMatcherTest.java** and **LoanMather.java** classes to replace _EMPRÉSTIMO_PESSOAL_ to _PERSONAL_LOAN_;
- Add white space in readme.md to fix slashes identation