### PR TITLE
Ajustando teste inválido no desafio de Ruby

### DIFF
--- a/backend/code-challenges/ruby/spec/loan_matcher_spec.rb
+++ b/backend/code-challenges/ruby/spec/loan_matcher_spec.rb
@@ -8,7 +8,7 @@ describe LoanMatcher do
       result = described_class.new(customer: customer).get_loans_from_customer
 
       expect(result.size).to eq 1
-      expect(result).to include([Loan.new(type: 'PERSONAL_LOAN')])
+      expect(result).to include(Loan.new(type: 'PERSONAL_LOAN'))
     end
   end
 end


### PR DESCRIPTION
### Motivação
O teste de ruby estava com um assertion inválido pois no include estava esperando um array e não só o elemento

### O que foi feito
- Ajustando teste para considerar o objeto e não o array.