### PR TITLE
Corrige o README em inglês do teste de Node.js

### DIFF
--- a/backend/code-challenges/node/README.md
+++ b/backend/code-challenges/node/README.md
@@ -32,7 +32,7 @@ The application must receive the following data as input:
     "name": "Erikaya",
     "cpf": "123.456.789-10",
     "age": 29,
-    "location": "SP",
+    "location": "BH",
     "income": 3000
   }
 }


### PR DESCRIPTION
Há uma diferença entre o README em inglês e o em português, onde pode confundir, pois o resultado será diferente (e pode acontecer erro de interpretação do problema). O REAME em inglês está com SP e o em português com BH, pelo output fornecido em ambos parece ser mais correto o BH.